### PR TITLE
fix: allow overriding `jsdom` behaviors via `@jest/environment-jsdom-abstract`

### DIFF
--- a/.cursor/rules.md
+++ b/.cursor/rules.md
@@ -1,0 +1,861 @@
+# Jest Project Rules for Cursor Agents
+
+This document provides comprehensive rules and guidelines for Cursor agents working on the Jest project. Understanding these rules will help you navigate the codebase, make appropriate changes, and follow the project's conventions.
+
+## Project Overview
+
+Jest is a delightful JavaScript testing framework with a focus on simplicity. It's a large-scale monorepo managed with Yarn workspaces and lerna-lite.
+
+- **Repository**: https://github.com/jestjs/jest
+- **License**: MIT
+- **Maintainer**: Meta Platforms, Inc. and affiliates
+- **Current Version**: 30.2.0 (as of this document)
+
+## Project Structure
+
+### 1. Monorepo Architecture
+
+Jest uses a **monorepo structure** with Yarn workspaces:
+
+```
+jest/
+├── packages/           # 54+ individual packages
+├── e2e/               # End-to-end integration tests
+├── examples/          # Example projects (Angular, React Native, etc.)
+├── docs/              # Documentation source files
+├── website/           # Docusaurus-based documentation website
+├── scripts/           # Build and maintenance scripts
+└── benchmarks/        # Performance benchmarks
+```
+
+### 2. Key Packages
+
+The project consists of 54+ packages in the `packages/` directory. Key packages include:
+
+**Core Packages:**
+
+- `jest` - Main package that users install
+- `jest-cli` - Command-line interface (entry point: `bin/jest.js`)
+- `jest-core` - Core orchestration logic
+- `jest-config` - Configuration handling
+- `jest-runtime` - Test runtime environment
+- `jest-circus` - Default test runner (replaces jest-jasmine2)
+- `jest-jasmine2` - Legacy Jasmine-based test runner
+
+**Testing Infrastructure:**
+
+- `expect` - Assertion library
+- `jest-snapshot` - Snapshot testing
+- `jest-mock` - Mocking utilities
+- `jest-matcher-utils` - Utilities for matchers
+- `jest-message-util` - Error message formatting
+
+**Build & Transform:**
+
+- `babel-jest` - Babel transformer
+- `jest-transform` - File transformation system
+- `babel-plugin-jest-hoist` - Hoists jest.mock calls
+
+**Utilities:**
+
+- `jest-util` - General utilities
+- `jest-validate` - Configuration validation
+- `jest-worker` - Worker pool for parallel execution
+- `pretty-format` - Object formatting
+- `diff-sequences` - Diff algorithm
+
+**Environment:**
+
+- `jest-environment` - Base environment interface
+- `jest-environment-node` - Node.js environment
+- `jest-environment-jsdom` - Browser-like environment
+
+### 3. Package Structure
+
+Each package follows a consistent structure:
+
+```
+packages/package-name/
+├── src/                    # TypeScript source code
+│   ├── __tests__/         # Unit tests for this package
+│   │   ├── __snapshots__/ # Snapshot files
+│   │   └── tsconfig.json  # Test-specific TypeScript config
+│   └── index.ts           # Main entry point
+├── build/                  # Compiled JavaScript (gitignored)
+├── package.json           # Package metadata
+├── tsconfig.json          # TypeScript configuration
+└── api-extractor.json     # API documentation config
+```
+
+## Development Workflow
+
+### 1. Prerequisites
+
+- **Node.js**: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0
+- **Yarn**: 4.10.3 (managed via corepack)
+- **Python**: Required for node-gyp during installation
+- **Mercurial (hg)**: Optional, needed for some tests
+
+### 2. Setup Commands
+
+```bash
+# Enable corepack for Yarn
+corepack enable
+
+# Install dependencies
+yarn install
+
+# Build all packages
+yarn build
+
+# Build steps breakdown:
+yarn build:js    # Compile JS with webpack
+yarn build:ts    # Compile TypeScript
+yarn bundle:ts   # Bundle type definitions
+```
+
+### 3. Development Commands
+
+```bash
+# Run tests
+yarn test                    # Run all tests (lint + jest)
+yarn jest                    # Run Jest tests only
+yarn jest --watch            # Watch mode
+
+# Run specific tests
+yarn jest <pattern>          # Run tests matching pattern
+yarn jest packages/jest-core # Run tests for specific package
+
+# Linting
+yarn lint                    # Run ESLint
+yarn lint:prettier           # Format with Prettier
+yarn lint:prettier:ci        # Check formatting
+
+# Type checking
+yarn typecheck               # Check TypeScript types
+yarn typecheck:examples      # Check example projects
+yarn typecheck:tests         # Check test files
+
+# Watch mode for development
+yarn watch                   # Watch and rebuild on changes
+yarn watch:ts                # Watch TypeScript only
+
+# CI-specific
+yarn test-ci-partial         # Run tests in CI mode
+yarn jest-jasmine            # Run with jest-jasmine2 runner
+```
+
+### 4. Build System
+
+The project uses a **custom build system** with multiple stages:
+
+1. **JavaScript Build** (`scripts/build.mjs`):
+
+   - Uses Webpack to bundle packages
+   - Transforms TypeScript to CommonJS and ESM
+   - Handles workspace dependencies
+
+2. **TypeScript Build** (`scripts/buildTs.mjs`):
+
+   - Generates `.d.ts` type definition files
+   - Uses TypeScript's project references
+
+3. **Type Bundling** (`scripts/bundleTs.mjs`):
+   - Uses API Extractor to create bundled type definitions
+   - Generates `api-extractor.json` files
+
+## Code Standards
+
+### 1. TypeScript Configuration
+
+**Main Config** (`tsconfig.json`):
+
+```json
+{
+  "extends": "@tsconfig/node18/tsconfig.json",
+  "compilerOptions": {
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": false,
+    "isolatedModules": true
+  }
+}
+```
+
+**Key Points:**
+
+- All packages use TypeScript
+- Strict mode is enabled
+- Each package has its own `tsconfig.json` that extends the root
+- Test files have separate `tsconfig.json` in `__tests__/` directories
+
+### 2. Code Style (ESLint + Prettier)
+
+**ESLint Config** (`eslint.config.mjs`):
+
+- Uses flat config format (ESLint 9+)
+- Extends: TypeScript ESLint, Unicorn, Promise, Import-X
+- Custom rules for Jest-specific patterns
+
+**Prettier Config** (in `package.json`):
+
+```json
+{
+  "bracketSpacing": false,
+  "proseWrap": "never",
+  "singleQuote": true,
+  "trailingComma": "all",
+  "arrowParens": "avoid"
+}
+```
+
+**Key Conventions:**
+
+- 2 spaces for indentation (no tabs)
+- 80 character line length strongly preferred
+- Single quotes for strings
+- Semicolons required
+- Trailing commas everywhere
+- No abbreviations in variable names ("Avoid abbreviating words")
+
+### 3. File Headers
+
+All source files must include the copyright header:
+
+```typescript
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+```
+
+### 4. Import Rules
+
+**Order** (enforced by ESLint):
+
+1. Built-in Node.js modules
+2. External dependencies
+3. Internal workspace packages (e.g., `@jest/*`, `jest-*`)
+4. Parent directory imports
+5. Sibling imports
+6. Index imports
+
+**Type Imports:**
+
+- Use inline type imports: `import {type Foo} from 'bar'`
+- Avoid side effects: `@typescript-eslint/no-import-type-side-effects`
+
+**Restricted Imports:**
+
+- Never import `fs` directly - use `graceful-fs` instead
+- Never use `global` - use `globalThis` instead
+
+### 5. Naming Conventions
+
+- **Files**: Use camelCase for most files, PascalCase for classes
+- **Test files**: `*.test.ts`, `*.test.js`
+- **Type files**: `*.d.ts`
+- **Config files**: `*.config.js`, `*.config.ts`, `*.config.mjs`
+- **Snapshot files**: Stored in `__snapshots__/` directory
+
+## Testing
+
+### 1. Test Structure
+
+**Unit Tests:**
+
+- Located in `packages/*/src/__tests__/`
+- Test the package in isolation
+- Use Jest's own testing framework
+- Fast execution
+
+**Integration Tests (E2E):**
+
+- Located in `e2e/` directory
+- Test Jest as a whole by running it on fixture projects
+- Use `runJest()` helper from `e2e/runJest.ts`
+- Slower but comprehensive
+
+### 2. E2E Test Structure
+
+```
+e2e/
+├── __tests__/              # Test files that run Jest on fixtures
+│   ├── failures.test.ts   # Tests failure scenarios
+│   └── ...
+├── failures/               # Fixture project for failure tests
+│   ├── __tests__/         # Test files that Jest will run
+│   ├── package.json
+│   └── ...
+└── Utils.ts                # Utilities for E2E tests
+```
+
+**E2E Test Pattern:**
+
+```typescript
+import runJest from '../runJest';
+
+test('test name', () => {
+  const {stdout, stderr, exitCode} = runJest('fixture-dir', ['args']);
+  expect(stderr).toMatchSnapshot();
+});
+```
+
+### 3. Running Tests
+
+**Test Runners:**
+
+- **jest-circus** (default): Modern test runner
+- **jest-jasmine2** (legacy): Use `JEST_JASMINE=1` environment variable
+
+**Key Test Commands:**
+
+```bash
+# Run all tests
+yarn jest
+
+# Run specific package tests
+yarn jest packages/jest-core
+
+# Run E2E tests
+yarn jest e2e/__tests__/failures.test.ts
+
+# Run with jasmine2
+JEST_JASMINE=1 yarn jest
+
+# Run with coverage
+yarn jest-coverage
+
+# Detect memory leaks
+yarn test-leak
+```
+
+### 4. Snapshot Testing
+
+- Snapshots stored in `__snapshots__/` directories
+- Use `toMatchSnapshot()` for output verification
+- Update snapshots with `-u` flag
+- Serializers: `jest-serializer-ansi-escapes` for ANSI codes
+
+### 5. Test Utilities
+
+**Key Utilities:**
+
+- `@jest/test-utils` - Testing utilities for Jest itself
+- `e2e/Utils.ts` - E2E test helpers
+- `e2e/runJest.ts` - Run Jest programmatically in tests
+
+## Package Management
+
+### 1. Workspace Dependencies
+
+**Workspace Protocol:**
+
+```json
+{
+  "dependencies": {
+    "@jest/types": "workspace:*",
+    "jest-util": "workspace:*"
+  }
+}
+```
+
+- All internal dependencies use `workspace:*`
+- Yarn resolves these to the local packages
+- Ensures consistency across the monorepo
+
+### 2. Dependency Constraints
+
+Enforced by `yarn.config.cjs`:
+
+1. **Same version across workspaces**: All packages must use the same version of external dependencies (except exceptions like `@types/node`)
+2. **No duplicate dependencies**: A package cannot list the same dependency in both `dependencies` and `devDependencies`
+3. **Repository field**: All packages must have correct repository information
+
+**Check constraints:**
+
+```bash
+yarn constraints        # Check for violations
+yarn constraints --fix  # Auto-fix violations
+```
+
+### 3. Package.json Structure
+
+Every package must have:
+
+```json
+{
+  "name": "package-name",
+  "version": "30.2.0",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/index.d.ts",
+      "require": "./build/index.js",
+      "import": "./build/index.mjs",
+      "default": "./build/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "engines": {
+    "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jestjs/jest.git",
+    "directory": "packages/package-name"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}
+```
+
+## Architecture Concepts
+
+### 1. Test Runners
+
+Jest supports two test runners:
+
+**jest-circus** (default, modern):
+
+- Event-driven architecture
+- Better async support
+- Concurrent test execution
+- Located in `packages/jest-circus/`
+
+**jest-jasmine2** (legacy):
+
+- Based on Jasmine 2.x
+- Maintained for backwards compatibility
+- Located in `packages/jest-jasmine2/`
+
+### 2. Test Execution Flow
+
+1. **CLI** (`jest-cli`) - Parse arguments, load config
+2. **Core** (`jest-core`) - Orchestrate test execution
+3. **Config** (`jest-config`) - Resolve and validate configuration
+4. **Runtime** (`jest-runtime`) - Module loading and mocking
+5. **Runner** (`jest-circus` or `jest-jasmine2`) - Execute tests
+6. **Reporters** (`jest-reporters`) - Output results
+
+### 3. Module System
+
+**Transform Pipeline:**
+
+1. File is requested
+2. Check if transform is needed (via `transform` config)
+3. Apply transformer (e.g., `babel-jest`)
+4. Cache transformed result
+5. Execute in isolated environment
+
+**Key Packages:**
+
+- `jest-transform` - Transformation system
+- `jest-runtime` - Module resolution and execution
+- `jest-haste-map` - Fast file system crawler
+- `babel-jest` - Default Babel transformer
+
+### 4. Environments
+
+Tests run in isolated environments:
+
+- **jest-environment-node**: Node.js environment (default for Node projects)
+- **jest-environment-jsdom**: Browser-like environment with JSDOM
+
+## Configuration
+
+### 1. Jest Configuration Files
+
+Jest supports multiple config formats:
+
+- `jest.config.js` - CommonJS
+- `jest.config.mjs` - ES Modules
+- `jest.config.ts` - TypeScript
+- `jest.config.json` - JSON
+- `package.json` - Under `"jest"` key
+
+### 2. Project Configuration
+
+**Root Config** (`jest.config.mjs`):
+
+```javascript
+export default {
+  projects: ['<rootDir>', '<rootDir>/examples/*/'],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/examples/',
+    '/e2e/.*/__tests__',
+    // ... more patterns
+  ],
+  transform: {
+    '\\.[jt]sx?$': 'babel-jest',
+  },
+  // ... more options
+};
+```
+
+**CI Config** (`jest.config.ci.mjs`):
+
+- Used in continuous integration
+- May have different timeouts or settings
+
+### 3. Babel Configuration
+
+**Root Babel Config** (`babel.config.js`):
+
+```javascript
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {node: supportedNodeVersion},
+      },
+    ],
+  ],
+  overrides: [
+    {
+      presets: [
+        [
+          '@babel/preset-typescript',
+          {
+            allowDeclareFields: true,
+          },
+        ],
+      ],
+      test: /\.tsx?$/,
+    },
+  ],
+};
+```
+
+## Git Workflow
+
+### 1. Branch Strategy
+
+- **main**: Primary development branch
+- Feature branches: Create from `main`
+- `main` is unsafe - breaking changes may occur
+
+### 2. Commit Messages
+
+Follow conventional commit style:
+
+- Focus on "why" rather than "what"
+- Be concise (1-2 sentences)
+- Reference issue numbers when applicable
+
+### 3. Changelog
+
+**CHANGELOG.md** must be updated for:
+
+- New features
+- Bug fixes
+- Breaking changes
+
+**Format:**
+
+```markdown
+### Features
+
+- **[package-name]:** Description ([#PR_NUMBER](link))
+
+### Fixes
+
+- **[package-name]:** Description ([#PR_NUMBER](link))
+```
+
+Alphabetically order entries by package name.
+
+### 4. Pull Requests
+
+Before submitting:
+
+1. Run `yarn test` - All tests must pass
+2. Run `yarn lint` - No linting errors
+3. Update CHANGELOG.md
+4. Add tests for new features
+5. Update documentation if APIs changed
+
+## Publishing
+
+### 1. Versioning
+
+Uses **lerna-lite** for version management:
+
+```bash
+yarn lerna publish
+```
+
+This will:
+
+1. Prompt for version bump
+2. Update all package versions
+3. Create git tags
+4. Publish to npm
+
+### 2. Pre-releases
+
+```bash
+yarn lerna publish 30.0.0-alpha.5 --preid alpha --pre-dist-tag next --dist-tag next
+```
+
+## Documentation
+
+### 1. Documentation Structure
+
+```
+docs/                    # Markdown documentation source
+website/                 # Docusaurus website
+├── versioned_docs/     # Previous version docs
+├── versioned_sidebars/ # Previous version sidebars
+└── blog/               # Blog posts
+```
+
+### 2. Updating Documentation
+
+1. Edit files in `docs/` for current version
+2. Check if older versions need updates in `website/versioned_docs/`
+3. Test locally:
+   ```bash
+   cd website
+   yarn
+   yarn start
+   ```
+
+### 3. API Documentation
+
+- Generated from TypeScript types using API Extractor
+- Configuration in `api-extractor.json` files
+- JSDoc comments become API documentation
+
+## Common Tasks
+
+### 1. Adding a New Package
+
+1. Create directory in `packages/`
+2. Create `package.json` with required fields
+3. Create `src/index.ts`
+4. Create `tsconfig.json`
+5. Add to workspaces (automatic with `packages/*`)
+6. Run `yarn install` to link
+
+### 2. Adding a New Feature
+
+1. Create feature branch
+2. Write tests first (TDD)
+3. Implement feature
+4. Update documentation
+5. Update CHANGELOG.md
+6. Run full test suite
+7. Submit PR
+
+### 3. Fixing a Bug
+
+1. Write failing test that reproduces bug
+2. Fix the bug
+3. Ensure test passes
+4. Update CHANGELOG.md
+5. Submit PR
+
+### 4. Running E2E Tests
+
+```bash
+# Run specific E2E test
+yarn jest e2e/__tests__/failures.test.ts
+
+# Run Jest manually on an E2E fixture
+cd e2e/failures
+node ../../packages/jest-cli/bin/jest.js
+
+# Debug E2E test
+node --inspect ../../packages/jest-cli/bin/jest.js
+```
+
+## Debugging
+
+### 1. Debug Tests
+
+```bash
+# Debug with Node inspector
+node --inspect-brk node_modules/.bin/jest --runInBand
+
+# Debug specific test
+node --inspect-brk packages/jest-cli/bin/jest.js path/to/test
+```
+
+### 2. Debug Build
+
+```bash
+# Verbose build output
+yarn build:js --verbose
+```
+
+### 3. Common Issues
+
+**Issue**: Tests fail with "Cannot find module"
+
+- **Solution**: Run `yarn build` to compile packages
+
+**Issue**: Type errors in IDE
+
+- **Solution**: Run `yarn build:ts` to generate type definitions
+
+**Issue**: E2E tests fail
+
+- **Solution**: Ensure fixture has `yarn install` run, check `runYarnInstall()` in test
+
+## Important Files Reference
+
+### Configuration Files
+
+- `package.json` - Root package, scripts, workspaces
+- `jest.config.mjs` - Jest configuration
+- `jest.config.ci.mjs` - CI-specific Jest config
+- `eslint.config.mjs` - ESLint configuration
+- `tsconfig.json` - TypeScript configuration
+- `babel.config.js` - Babel configuration
+- `lerna.json` - Lerna configuration
+- `yarn.config.cjs` - Yarn constraints
+
+### Build Scripts
+
+- `scripts/build.mjs` - Main build script
+- `scripts/buildTs.mjs` - TypeScript build
+- `scripts/bundleTs.mjs` - Type bundling
+- `scripts/buildUtils.mjs` - Build utilities
+- `scripts/watch.mjs` - Watch mode
+
+### Documentation
+
+- `README.md` - Project README
+- `CONTRIBUTING.md` - Contribution guidelines
+- `CHANGELOG.md` - Version history
+- `docs/Architecture.md` - Architecture overview
+
+### Testing Utilities
+
+- `e2e/Utils.ts` - E2E test utilities
+- `e2e/runJest.ts` - Run Jest in E2E tests
+- `packages/test-utils/` - Testing utilities
+
+## Key Principles
+
+### 1. Backwards Compatibility
+
+- Jest maintains backwards compatibility
+- Deprecations are warned before removal
+- Breaking changes only in major versions
+
+### 2. Performance
+
+- Fast test execution is a priority
+- Worker pools for parallelization
+- Efficient file watching and caching
+
+### 3. Developer Experience
+
+- Clear error messages
+- Helpful CLI output
+- Interactive watch mode
+- Snapshot testing for easy assertions
+
+### 4. Extensibility
+
+- Plugin system for reporters
+- Custom matchers
+- Custom test environments
+- Custom transformers
+
+## Anti-Patterns to Avoid
+
+1. **Don't** import `fs` directly - use `graceful-fs`
+2. **Don't** use `global` - use `globalThis`
+3. **Don't** skip tests without good reason
+4. **Don't** commit without running linter
+5. **Don't** add dependencies without checking constraints
+6. **Don't** modify `node_modules` - use patches if needed
+7. **Don't** use `any` type unless absolutely necessary
+8. **Don't** create files without copyright headers
+9. **Don't** use interactive git commands in scripts (no `-i` flag)
+10. **Don't** push to remote without explicit request
+
+## Useful Commands Cheatsheet
+
+```bash
+# Setup
+corepack enable
+yarn install
+yarn build
+
+# Development
+yarn watch                    # Watch and rebuild
+yarn jest --watch            # Watch tests
+
+# Testing
+yarn test                    # Full test suite
+yarn jest <pattern>          # Specific tests
+JEST_JASMINE=1 yarn jest    # Use jasmine2 runner
+yarn test-leak              # Memory leak detection
+
+# Code Quality
+yarn lint                    # Lint code
+yarn lint:prettier          # Format code
+yarn typecheck              # Type check
+yarn constraints            # Check dependencies
+
+# Building
+yarn build:js               # Build JavaScript
+yarn build:ts               # Build TypeScript
+yarn bundle:ts              # Bundle types
+yarn build-clean            # Clean build artifacts
+
+# Publishing
+yarn lerna publish          # Publish new version
+
+# Documentation
+cd website && yarn start    # Run docs locally
+
+# Utilities
+yarn clean-all              # Clean everything
+yarn clean-e2e              # Clean E2E fixtures
+```
+
+## Resources
+
+- **Website**: https://jestjs.io
+- **GitHub**: https://github.com/jestjs/jest
+- **Discord**: #testing on Reactiflux
+- **Contributing Guide**: CONTRIBUTING.md
+- **Code of Conduct**: CODE_OF_CONDUCT.md
+
+## Summary for Cursor Agents
+
+When working on Jest:
+
+1. **Understand the monorepo structure** - 54+ packages with interdependencies
+2. **Follow TypeScript and ESLint rules** - Strict typing, consistent style
+3. **Write tests** - Unit tests in `__tests__/`, E2E tests in `e2e/`
+4. **Build before testing** - Run `yarn build` after changes
+5. **Update CHANGELOG** - Document all user-facing changes
+6. **Use workspace dependencies** - `workspace:*` for internal packages
+7. **Respect the architecture** - Understand test runners, transforms, environments
+8. **Test with both runners** - jest-circus (default) and jest-jasmine2
+9. **Check constraints** - Run `yarn constraints` before committing
+10. **Read existing code** - Jest has excellent examples throughout
+
+This project is large but well-organized. Take time to understand the architecture before making changes. When in doubt, look at existing patterns in the codebase.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,759 @@
+# GitHub Copilot Instructions for Jest Project
+
+This document provides instructions for GitHub Copilot when working on the Jest codebase. These guidelines will help generate appropriate code suggestions that align with the project's architecture and conventions.
+
+## Project Context
+
+Jest is a JavaScript testing framework maintained by Meta Platforms. It's a large monorepo with 54+ packages managed using Yarn workspaces and lerna-lite.
+
+- **Language**: TypeScript (strict mode)
+- **Package Manager**: Yarn 4.10.3
+- **Node Version**: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0
+- **License**: MIT
+
+## Code Style Guidelines
+
+### TypeScript
+
+- Always use TypeScript with strict mode enabled
+- Prefer explicit return types on exported functions
+- Use inline type imports: `import {type Foo} from 'bar'`
+- Avoid `any` type - use `unknown` or proper types
+- Enable all strict compiler options
+
+### Formatting
+
+```typescript
+// Prettier configuration
+{
+  bracketSpacing: false,      // {foo: bar} not { foo: bar }
+  singleQuote: true,          // 'string' not "string"
+  trailingComma: 'all',       // Always add trailing commas
+  arrowParens: 'avoid',       // x => x not (x) => x
+  proseWrap: 'never',
+}
+```
+
+### Style Rules
+
+- Use 2 spaces for indentation (never tabs)
+- Prefer 80 character line length
+- Always use semicolons
+- Use single quotes for strings
+- Add trailing commas in arrays, objects, function parameters
+- No abbreviations in variable names
+
+### File Headers
+
+Every source file must start with:
+
+```typescript
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+```
+
+## Import Guidelines
+
+### Import Order
+
+Organize imports in this order:
+
+1. Node.js built-in modules
+2. External npm packages
+3. Internal workspace packages (`@jest/*`, `jest-*`)
+4. Parent directory imports (`../`)
+5. Sibling imports (`./`)
+
+### Import Restrictions
+
+```typescript
+// ❌ NEVER do this
+import fs from 'fs';
+const x = global.something;
+
+// ✅ ALWAYS do this
+import fs from 'graceful-fs';
+const x = globalThis.something;
+```
+
+**Rules:**
+
+- Never import `fs` - always use `graceful-fs`
+- Never use `global` - always use `globalThis`
+- Use `workspace:*` for internal package dependencies
+
+### Type Imports
+
+```typescript
+// ✅ Preferred - inline type imports
+import {someFunction, type SomeType} from './module';
+
+// ❌ Avoid - separate import statements
+import type {SomeType} from './module';
+import {someFunction} from './module';
+```
+
+## Package Structure
+
+When creating or modifying packages, follow this structure:
+
+```
+packages/package-name/
+├── src/
+│   ├── __tests__/           # Unit tests
+│   │   ├── __snapshots__/   # Snapshot files
+│   │   ├── *.test.ts        # Test files
+│   │   └── tsconfig.json    # Test TypeScript config
+│   ├── index.ts             # Main entry point
+│   └── *.ts                 # Source files
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+### Package.json Template
+
+```json
+{
+  "name": "package-name",
+  "version": "30.2.0",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/index.d.ts",
+      "require": "./build/index.js",
+      "import": "./build/index.mjs",
+      "default": "./build/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "dependencies": {
+    "@jest/types": "workspace:*"
+  },
+  "engines": {
+    "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jestjs/jest.git",
+    "directory": "packages/package-name"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}
+```
+
+## Testing Patterns
+
+### Unit Tests
+
+Located in `packages/*/src/__tests__/`:
+
+```typescript
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {functionToTest} from '../index';
+
+describe('functionToTest', () => {
+  it('should do something', () => {
+    const result = functionToTest('input');
+    expect(result).toBe('expected');
+  });
+
+  it('should handle edge cases', () => {
+    expect(() => functionToTest(null)).toThrow();
+  });
+});
+```
+
+### E2E Tests
+
+Located in `e2e/__tests__/`:
+
+```typescript
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as path from 'path';
+import {runYarnInstall} from '../Utils';
+import runJest from '../runJest';
+
+const dir = path.resolve(__dirname, '../fixture-name');
+
+beforeAll(() => {
+  runYarnInstall(dir);
+});
+
+test('description of test', () => {
+  const {stdout, stderr, exitCode} = runJest(dir, ['--option']);
+  expect(exitCode).toBe(0);
+  expect(stderr).toMatchSnapshot();
+});
+```
+
+### Snapshot Testing
+
+```typescript
+// Use snapshots for complex output
+expect(complexObject).toMatchSnapshot();
+
+// Use inline snapshots for simple values
+expect(simpleValue).toMatchInlineSnapshot(`'expected value'`);
+```
+
+## Common Patterns
+
+### Error Handling
+
+```typescript
+// ✅ Use ErrorWithStack for better stack traces
+import {ErrorWithStack} from 'jest-util';
+
+function validateInput(input: unknown): void {
+  if (typeof input !== 'string') {
+    throw new ErrorWithStack('Input must be a string', validateInput);
+  }
+}
+```
+
+### Async Operations
+
+```typescript
+// ✅ Prefer async/await over promises
+async function loadConfig(path: string): Promise<Config> {
+  const content = await fs.promises.readFile(path, 'utf8');
+  return JSON.parse(content);
+}
+
+// ✅ Handle errors properly
+try {
+  const config = await loadConfig(configPath);
+} catch (error) {
+  throw new ErrorWithStack(
+    `Failed to load config: ${error.message}`,
+    loadConfig,
+  );
+}
+```
+
+### Type Guards
+
+```typescript
+// ✅ Use type guards for runtime checks
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function processValue(value: unknown): string {
+  if (!isString(value)) {
+    throw new TypeError('Expected string');
+  }
+  return value.toUpperCase();
+}
+```
+
+### Module Exports
+
+```typescript
+// ✅ Use named exports (preferred)
+export function myFunction(): void {}
+export class MyClass {}
+export type MyType = {};
+
+// ⚠️ Default exports allowed for certain patterns
+export default class SpecialCase {}
+```
+
+## Architecture-Specific Patterns
+
+### Test Runner Code (jest-circus, jest-jasmine2)
+
+```typescript
+// When working with test runners, understand the event system
+import type {Circus} from '@jest/types';
+
+export const handleTestEvent = async (
+  event: Circus.Event,
+  state: Circus.State,
+): Promise<void> => {
+  switch (event.name) {
+    case 'test_start':
+      // Handle test start
+      break;
+    case 'test_done':
+      // Handle test completion
+      break;
+  }
+};
+```
+
+### Transform Code (babel-jest, jest-transform)
+
+```typescript
+// Transformers must implement the Transformer interface
+import type {Transformer} from '@jest/transform';
+
+const transformer: Transformer = {
+  process(sourceText, sourcePath, options) {
+    // Transform the source code
+    return {
+      code: transformedCode,
+      map: sourceMap,
+    };
+  },
+};
+
+export default transformer;
+```
+
+### Environment Code (jest-environment-\*)
+
+```typescript
+// Environments must extend JestEnvironment
+import {JestEnvironment} from '@jest/environment';
+import type {
+  EnvironmentContext,
+  JestEnvironmentConfig,
+} from '@jest/environment';
+
+export default class CustomEnvironment extends JestEnvironment {
+  constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
+    super(config, context);
+  }
+
+  async setup(): Promise<void> {
+    await super.setup();
+    // Setup logic
+  }
+
+  async teardown(): Promise<void> {
+    // Cleanup logic
+    await super.teardown();
+  }
+}
+```
+
+### Reporter Code (jest-reporters)
+
+```typescript
+// Reporters must implement the Reporter interface
+import type {Reporter, TestResult} from '@jest/reporters';
+
+export default class CustomReporter implements Reporter {
+  onTestResult(
+    test: Test,
+    testResult: TestResult,
+    results: AggregatedResult,
+  ): void {
+    // Handle test result
+  }
+
+  onRunComplete(): void {
+    // Handle run completion
+  }
+}
+```
+
+## Configuration Patterns
+
+### Jest Configuration
+
+```typescript
+// jest.config.ts or jest.config.js
+import type {Config} from '@jest/types';
+
+const config: Config.InitialOptions = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': 'babel-jest',
+  },
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/__tests__/**'],
+};
+
+export default config;
+```
+
+### TypeScript Configuration
+
+```json
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**"]
+}
+```
+
+## Performance Considerations
+
+### Worker Pools
+
+```typescript
+// Use jest-worker for parallel processing
+import {Worker} from 'jest-worker';
+
+const worker = new Worker(require.resolve('./worker'), {
+  numWorkers: 4,
+  enableWorkerThreads: true,
+});
+
+const result = await worker.processFile(filePath);
+await worker.end();
+```
+
+### Caching
+
+```typescript
+// Leverage caching for expensive operations
+import {createHash} from 'crypto';
+
+function getCacheKey(
+  sourceText: string,
+  sourcePath: string,
+  options: TransformOptions,
+): string {
+  return createHash('md5')
+    .update(sourceText)
+    .update(sourcePath)
+    .update(JSON.stringify(options))
+    .digest('hex');
+}
+```
+
+## Documentation
+
+### JSDoc Comments
+
+```typescript
+/**
+ * Processes a test file and returns the results.
+ *
+ * @param filePath - Path to the test file
+ * @param options - Test execution options
+ * @returns Promise resolving to test results
+ * @throws {Error} If file cannot be read
+ */
+export async function processTestFile(
+  filePath: string,
+  options: TestOptions,
+): Promise<TestResult> {
+  // Implementation
+}
+```
+
+### README Files
+
+Each package should have a README.md with:
+
+- Brief description
+- Installation instructions
+- Basic usage example
+- API documentation link
+
+## Common Utilities
+
+### File System Operations
+
+```typescript
+import fs from 'graceful-fs';
+import {promisify} from 'util';
+
+// ✅ Use promisified versions
+const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
+
+// Or use promises API directly
+await fs.promises.readFile(path, 'utf8');
+```
+
+### Path Handling
+
+```typescript
+import * as path from 'path';
+import slash from 'slash';
+
+// ✅ Normalize paths for cross-platform compatibility
+const normalizedPath = slash(path.resolve(dir, file));
+```
+
+### String Formatting
+
+```typescript
+import chalk from 'chalk';
+import dedent from 'dedent';
+
+// ✅ Use chalk for colored output
+console.log(chalk.green('Success!'));
+console.log(chalk.red('Error:'), message);
+
+// ✅ Use dedent for multi-line strings
+const message = dedent`
+  This is a multi-line
+  message that will be
+  properly dedented
+`;
+```
+
+## Debugging Patterns
+
+### Debug Logging
+
+```typescript
+// Use conditional logging based on environment
+const debug = process.env.DEBUG === 'true';
+
+if (debug) {
+  console.log('Debug info:', data);
+}
+```
+
+### Error Messages
+
+```typescript
+// ✅ Provide helpful error messages
+throw new Error(
+  `Failed to load module "${moduleName}" from "${modulePath}". ` +
+    `Make sure the module exists and is properly exported.`,
+);
+
+// ❌ Avoid vague errors
+throw new Error('Module not found');
+```
+
+## Version Compatibility
+
+### Node.js Version Checks
+
+```typescript
+import * as semver from 'semver';
+
+if (!semver.satisfies(process.version, '>=18.14.0')) {
+  throw new Error('Node.js 18.14.0 or higher is required');
+}
+```
+
+### Feature Detection
+
+```typescript
+// ✅ Use feature detection over version checks
+const hasWorkerThreads = typeof Worker !== 'undefined';
+```
+
+## Security Considerations
+
+### Input Validation
+
+```typescript
+// ✅ Always validate user input
+function validateConfig(config: unknown): Config {
+  if (typeof config !== 'object' || config === null) {
+    throw new TypeError('Config must be an object');
+  }
+
+  // Validate each field
+  return config as Config;
+}
+```
+
+### Path Traversal Prevention
+
+```typescript
+import * as path from 'path';
+
+// ✅ Prevent path traversal attacks
+function safeJoin(base: string, userPath: string): string {
+  const resolved = path.resolve(base, userPath);
+  if (!resolved.startsWith(base)) {
+    throw new Error('Path traversal detected');
+  }
+  return resolved;
+}
+```
+
+## Anti-Patterns to Avoid
+
+```typescript
+// ❌ Don't use var
+var x = 1;
+
+// ✅ Use const/let
+const x = 1;
+let y = 2;
+
+// ❌ Don't use == or !=
+if (x == '1') {
+}
+
+// ✅ Use === or !==
+if (x === 1) {
+}
+
+// ❌ Don't ignore errors
+try {
+  doSomething();
+} catch {}
+
+// ✅ Handle errors properly
+try {
+  doSomething();
+} catch (error) {
+  console.error('Failed to do something:', error);
+  throw error;
+}
+
+// ❌ Don't use any without good reason
+function process(data: any) {}
+
+// ✅ Use proper types
+function process(data: unknown) {
+  if (typeof data === 'string') {
+    // Now TypeScript knows data is a string
+  }
+}
+
+// ❌ Don't mutate parameters
+function addItem(arr: Array<string>, item: string) {
+  arr.push(item);
+  return arr;
+}
+
+// ✅ Return new values
+function addItem(arr: Array<string>, item: string): Array<string> {
+  return [...arr, item];
+}
+```
+
+## Monorepo-Specific Guidelines
+
+### Cross-Package Dependencies
+
+```json
+{
+  "dependencies": {
+    "@jest/types": "workspace:*",
+    "jest-util": "workspace:*"
+  }
+}
+```
+
+Always use `workspace:*` for internal dependencies.
+
+### Circular Dependencies
+
+Avoid circular dependencies between packages. If needed, extract shared code to a common package.
+
+### Package Boundaries
+
+Respect package boundaries - don't import from `src/` of other packages, only from their public exports.
+
+## Testing Best Practices
+
+### Test Organization
+
+```typescript
+describe('MyClass', () => {
+  describe('constructor', () => {
+    it('should initialize with default values', () => {});
+    it('should accept custom options', () => {});
+  });
+
+  describe('myMethod', () => {
+    it('should handle valid input', () => {});
+    it('should throw on invalid input', () => {});
+  });
+});
+```
+
+### Test Naming
+
+```typescript
+// ✅ Descriptive test names
+it('should throw TypeError when config is not an object', () => {});
+
+// ❌ Vague test names
+it('works', () => {});
+it('test 1', () => {});
+```
+
+### Setup and Teardown
+
+```typescript
+describe('FileProcessor', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDirectory();
+  });
+
+  afterEach(() => {
+    removeTempDirectory(tempDir);
+  });
+
+  it('should process files', () => {
+    // Test uses tempDir
+  });
+});
+```
+
+## Build and Development
+
+### Build Output
+
+Packages compile to:
+
+- `build/index.js` - CommonJS
+- `build/index.mjs` - ES Modules
+- `build/index.d.ts` - TypeScript definitions
+
+### Watch Mode
+
+When developing, use watch mode:
+
+```bash
+yarn watch  # Rebuilds on file changes
+```
+
+### Type Checking
+
+Always ensure types are correct:
+
+```bash
+yarn typecheck
+```
+
+## Summary
+
+When generating code for Jest:
+
+1. **Use TypeScript** with strict mode and proper types
+2. **Follow formatting rules** - 2 spaces, single quotes, trailing commas
+3. **Add copyright headers** to all source files
+4. **Import graceful-fs** instead of fs
+5. **Use workspace:\*** for internal dependencies
+6. **Write tests** for all new functionality
+7. **Handle errors** with descriptive messages
+8. **Document with JSDoc** for public APIs
+9. **Respect package boundaries** in the monorepo
+10. **Follow existing patterns** in the codebase
+
+The Jest codebase is mature and well-structured. When in doubt, look at existing code in the same package or similar packages for patterns to follow.

--- a/e2e/__tests__/custom-jsdom-version.test.ts
+++ b/e2e/__tests__/custom-jsdom-version.test.ts
@@ -7,10 +7,8 @@
 
 import path from 'node:path';
 import {onNodeVersions} from '@jest/test-utils';
-import runJest, {type RunJestResult} from '../runJest';
+import {json as runWithJson} from '../runJest';
 import {runYarnInstall} from '../Utils';
-
-const getLog = (result: RunJestResult) => result.stdout.split('\n')[1].trim();
 
 const dir = path.resolve(__dirname, '../custom-jsdom-version/v27');
 
@@ -20,8 +18,9 @@ beforeEach(() => {
 
 onNodeVersions('>=20.4.0', () => {
   it('should work with custom jsdom version', () => {
-    const result = runJest(dir, ['env.test.js']);
+    const result = runWithJson(dir, ['env.test.js']);
+
+    expect(result.json.numPassedTests).toBe(1);
     expect(result.exitCode).toBe(0);
-    expect(getLog(result)).toBe('WINDOW');
   });
 });

--- a/e2e/custom-jsdom-version/v27/__tests__/env.test.js
+++ b/e2e/custom-jsdom-version/v27/__tests__/env.test.js
@@ -6,6 +6,10 @@
  */
 'use strict';
 
-console.log(globalThis.window ? 'WINDOW' : 'NO WINDOW');
+const DummyLocation = require('../dummy-location');
 
-test('stub', () => expect(1).toBe(1));
+test('should work', () => {
+  expect(globalThis.document.location).toBeInstanceOf(DummyLocation);
+  globalThis.document.location.search = 'foo=bar';
+  expect(globalThis.document.location.search).toBe('foo=bar');
+});

--- a/e2e/custom-jsdom-version/v27/custom-jsdom-env.js
+++ b/e2e/custom-jsdom-version/v27/custom-jsdom-env.js
@@ -5,11 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import JSDOM from 'jsdom';
+import jsdom from 'jsdom';
 import BaseEnv from '@jest/environment-jsdom-abstract';
+import {JSDOMWithDummyLocation} from './dummy-jsdom.js';
 
 export default class JestJSDOMEnvironment extends BaseEnv {
   constructor(config, context) {
-    super(config, context, JSDOM);
+    super(config, context, {
+      ...jsdom,
+      JSDOM: JSDOMWithDummyLocation,
+    });
   }
 }

--- a/e2e/custom-jsdom-version/v27/dummy-jsdom.js
+++ b/e2e/custom-jsdom-version/v27/dummy-jsdom.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as jsdom from 'jsdom';
+import DummyLocation from './dummy-location.js';
+
+export class JSDOMWithDummyLocation extends jsdom.JSDOM {
+  #mockLocation = new DummyLocation();
+  #documentProxy = new Proxy(super.window.document, {
+    get: (target, prop, receiver) => {
+      if (prop !== 'location') return Reflect.get(target, prop, receiver);
+      return this.#mockLocation;
+    },
+  });
+  #windowProxy = new Proxy(super.window, {
+    get: (target, prop, receiver) => {
+      switch (prop) {
+        case 'document':
+          return this.#documentProxy;
+        case 'location':
+          return this.#mockLocation;
+        default:
+          return Reflect.get(target, prop, receiver);
+      }
+    },
+  });
+
+  get window() {
+    return this.#windowProxy;
+  }
+}

--- a/e2e/custom-jsdom-version/v27/dummy-location.js
+++ b/e2e/custom-jsdom-version/v27/dummy-location.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+class DummyLocation {
+  hash = '';
+  host = '';
+  hostname = '';
+  href = '';
+  toString() {
+    return this.href;
+  }
+  origin = '';
+  pathname = '';
+  port = '';
+  protocol = '';
+  search = '';
+  /** @param {string | URL} url */
+  assign(url) {
+    this.href = String(url);
+  }
+  reload() {}
+  /** @param {string | URL} url */
+  replace(url) {
+    this.href = String(url);
+  }
+}
+
+module.exports = DummyLocation;

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -44,6 +44,9 @@ export declare class JestEnvironment<Timer = unknown> {
   fakeTimersModern: ModernFakeTimers | null;
   moduleMocker: ModuleMocker | null;
   getVmContext(): Context | null;
+  /**
+   * Allow customizing the environment after being created
+   */
   setup(): Promise<void>;
   teardown(): Promise<void>;
   handleTestEvent?: Circus.EventHandler;

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -270,11 +270,7 @@ async function runTestInternal(
   // For runtime errors
   sourcemapSupport.install(sourcemapOptions);
 
-  if (
-    environment.global &&
-    environment.global.process &&
-    environment.global.process.exit
-  ) {
+  if (environment.global.process?.exit) {
     const realExit = environment.global.process.exit;
 
     environment.global.process.exit = function exit(...args: Array<any>) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Assign `global` property of `BaseJSDOMEnvironment` to `globalThis` and assign all things directly to `globalThis`.

This would allow users to customize `jsdom` behaviors easier since JSDOM 21+ doesn't allow mutation on `window` anymore.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Updated e2e tests

Green CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSDOM environment initialization, teardown and error forwarding to surface window errors reliably and handle console variations.

* **Tests**
  * Updated end-to-end tests to validate a mocked location implementation and better capture JSON test results for more robust environment verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->